### PR TITLE
Update CLAUDE.md and add kernel shell reboot command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 **Helios** is a liquid fuel burner ignition control unit (ICU) firmware for diesel-like fuels including diesel, kerosene, used vegetable oil, and used motor oil. It runs on Zephyr RTOS and manages the complete combustion lifecycle from ignition to safe shutdown.
 
 **Hardware:**
-- **Development Board:** Raspberry Pi Pico 2 (RP2350a, ARM Cortex-M33)
+- **Development Board:** Raspberry Pi Pico 2 (RP2350A, ARM Cortex-M33)
 - **Production Target:** Custom board with RP2354A (pending burn test completion)
 - **Current Status:** Burn testing on Pico 2 development board
 
@@ -616,13 +616,36 @@ This project was developed with assistance from Claude (Anthropic). All signific
 - Modular communication library for shared use between ICU and controller
 - Safety features for emergency conditions
 
-**Last Updated:** 2026-01-09
+**Last Updated:** 2026-01-15
 
 ---
 
 ## AI Assistant Operations
 
-To reload all organization CLAUDE.md files or run a content integrity check, see the **CLAUDE.md Reload** and **Content Integrity Check** sections in the [Thermoquad Organization CLAUDE.md](../../CLAUDE.md).
+### Content Integrity Check
+
+To verify consistency across all CLAUDE.md files in the organization, see the **Content Integrity Check** section in the [Thermoquad Organization CLAUDE.md](../../CLAUDE.md).
+
+**How to Request:** Ask the AI assistant to "run a content integrity check on all CLAUDE.md files"
+
+### Content Status Integrity Check
+
+To validate that this CLAUDE.md accurately reflects the actual Helios firmware implementation, see the **Content Status Integrity Check** section in the [Thermoquad Organization CLAUDE.md](../../CLAUDE.md).
+
+**How to Request:** Ask the AI assistant to "run a content status integrity check on helios"
+
+**What Gets Checked for Helios:**
+- Device counts match code: Motors (check `DEVICE_MOTOR_COUNT`), thermometers, pumps, glow plugs
+- State machine states match `helios_state_t` enum in code
+- Controller thread count matches documentation
+- prj.conf Kconfig options match documented features
+- app.overlay device tree matches documented hardware
+- Fusain integration matches documented usage
+- Build system works as documented (task build-firmware succeeds)
+
+### CLAUDE.md Reload
+
+To reload all organization CLAUDE.md files, see the **CLAUDE.md Reload** section in the [Thermoquad Organization CLAUDE.md](../../CLAUDE.md).
 
 ---
 

--- a/prj.conf
+++ b/prj.conf
@@ -15,6 +15,10 @@ CONFIG_ADC_SHELL=y
 CONFIG_SENSOR_SHELL=y
 CONFIG_LOG_CMDS=y
 
+# Reboot Command (non-default delay)
+CONFIG_REBOOT=y
+CONFIG_KERNEL_SHELL_REBOOT_DELAY=250
+
 # State machine framework
 CONFIG_SMF=y
 


### PR DESCRIPTION
## Changes

- Update Helios CLAUDE.md with AI Assistant Operations sections
- Fix typo: RP2350a → RP2350A
- Add kernel shell reboot command (CONFIG_REBOOT=y, 250ms delay)

Matches Slate configuration for shell reboot functionality.